### PR TITLE
Set $metadataPrefix in getRecordListParams()

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -619,7 +619,7 @@ class Provider
                     );
                 }
             },
-            function () use ($metadataPrefix) {
+            function () use (&$metadataPrefix) {
                 if (!isset($this->params['metadataPrefix'])) {
                     throw new BadArgumentException("Missing required argument metadataPrefix");
                 }


### PR DESCRIPTION
Since the value is set in a closure, it must be passed by reference