### PR TITLE
Fix Response Content-Type Header

### DIFF
--- a/src/ResponseDocument.php
+++ b/src/ResponseDocument.php
@@ -38,7 +38,7 @@ class ResponseDocument
     /**
      * @var string[]
      */
-    private $headers = ['Content-Type: text/xml; charset=utf8'];
+    private $headers = ['Content-Type' => 'text/xml; charset=utf8'];
 
     /**
      * @var string


### PR DESCRIPTION
Currently the HTTP Response has the following headers:
```
0: Content-Type: text/xml; charset=utf8
Content-Type: text/html; charset=UTF-8
...
```
When we pass the header array as [$key => $value], we have a correct Content-Type header.
