### PR TITLE
Fixed feature as agreed with David: Provider's getResponse method cat…

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -172,9 +172,9 @@ class Provider
         } catch (\Exception $error) {
             //add this error to the response
             if ($error instanceof Exception) {
-               $this->response->addError($error);
+                $this->response->addError($error);
             } else {
-              $this->response->addError(new Exception($error->getMessage()));
+                $this->response->addError(new Exception($error->getMessage()));
             }
         }
 

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -169,9 +169,9 @@ class Provider
             foreach ($errors as $error) {
                 $this->response->addError($error);
             }
-        } catch (Exception $error) {
+        } catch (\Exception $error) {
             //add this error to the response
-            $this->response->addError($error);
+            $this->response->addError(new Exception($error->getMessage()));
         }
 
         return $this->response->getResponse();

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -171,7 +171,11 @@ class Provider
             }
         } catch (\Exception $error) {
             //add this error to the response
-            $this->response->addError(new Exception($error->getMessage()));
+            if ($error instanceof Exception) {
+               $this->response->addError($error);
+            } else {
+              $this->response->addError(new Exception($error->getMessage()));
+            }
         }
 
         return $this->response->getResponse();

--- a/src/ResponseDocument.php
+++ b/src/ResponseDocument.php
@@ -105,6 +105,8 @@ class ResponseDocument
         $this->status = '400';
         if ($error->getErrorName()) {
             $errorNode->setAttribute("code", $error->getErrorName());
+        } else {
+            $errorNode->setAttribute("code", "badArgument");
         }
     }
 


### PR DESCRIPTION
…ches now any \Expression, makes am OaiPmh-Expressions out of it and adds to the xml for erroneous response.