### PR TITLE
fixes issue #8: namespaces of records are inherited by OAI elements

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -97,6 +97,11 @@ class Provider
     private $request;
 
     /**
+     * @var array
+     */
+    private $records = [];
+
+    /**
      * @param Repository $repository
      * @param ServerRequestInterface $request
      */
@@ -164,6 +169,15 @@ class Provider
             // the element is only added when everything went fine, otherwise we would add error node(s) in the catch
             // block below
             $this->response->getDocument()->documentElement->appendChild($verbOutput);
+
+            // Shift the records from the records stack and add them to the DOM tree
+            // Records proper are always stored in the 'metadata' node
+            foreach ($this->response->getDocument()->getElementsByTagName('metadata') as $item) {
+               $record = array_shift($this->records);
+               $node = $this->response->getDocument()->importNode($record->documentElement, true);
+               $item->appendChild($node);
+            }
+
         } catch (MultipleExceptions $errors) {
             //multiple errors happened add all of the to the response
             foreach ($errors as $error) {
@@ -246,7 +260,10 @@ class Provider
 
         // Only add metadata and about if the record is not deleted.
         if (!$header->isDeleted()) {
-            $recordNode->appendChild($this->response->createElement('metadata', $record->getMetadata()));
+            $recordNode->appendChild($this->response->createElement('metadata'));
+
+            // Push the record itself on the records stack
+            array_push($this->records, $record->getMetadata());
 
             //only add an 'about' node if it's not null
             $about = $record->getAbout();
@@ -430,7 +447,10 @@ class Provider
 
             // Only add metadata and about if the record is not deleted.
             if (!$header->isDeleted()) {
-                $recordNode->appendChild($this->response->createElement('metadata', $record->getMetadata()));
+                $recordNode->appendChild($this->response->createElement('metadata'));
+
+                // Push the record itself on the records stack
+                array_push($this->records, $record->getMetadata());
 
                 //only add an 'about' node if it's not null
                 $about = $record->getAbout();

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -173,11 +173,10 @@ class Provider
             // Shift the records from the records stack and add them to the DOM tree
             // Records proper are always stored in the 'metadata' node
             foreach ($this->response->getDocument()->getElementsByTagName('metadata') as $item) {
-               $record = array_shift($this->records);
-               $node = $this->response->getDocument()->importNode($record->documentElement, true);
-               $item->appendChild($node);
+                $record = array_shift($this->records);
+                $node = $this->response->getDocument()->importNode($record->documentElement, true);
+                $item->appendChild($node);
             }
-
         } catch (MultipleExceptions $errors) {
             //multiple errors happened add all of the to the response
             foreach ($errors as $error) {

--- a/src/ResponseDocument.php
+++ b/src/ResponseDocument.php
@@ -136,14 +136,7 @@ class ResponseDocument
     public function createElement($name, $value = null)
     {
         $nameSpace = 'http://www.openarchives.org/OAI/2.0/';
-
-        if ($value instanceof \DOMDocument) {
-            $element = $this->document->createElementNS($nameSpace, $name, null);
-            $node = $this->document->importNode($value->documentElement, true);
-            $element->appendChild($node);
-        } else {
-            $element = $this->document->createElementNS($nameSpace, $name, htmlspecialchars($value, ENT_XML1));
-        }
+        $element = $this->document->createElementNS($nameSpace, $name, htmlspecialchars($value, ENT_XML1));
         return $element;
     }
 


### PR DESCRIPTION
Manually tested. And PHPUNit tests are still green. So this works. The excess xmlns namespaces are omitted from the document.

Tough, I can't add an explicit unit test. It's not possible to create an explicit XPath query which selects elements with an 'xmlns' attribute.  XPath operates on a DOM model, not on the actual source text, which makes such a query irrelevant with an XPath context.