### PR TITLE
NoRecordsMatchException should be served with HTTP code 200

### DIFF
--- a/src/ResponseDocument.php
+++ b/src/ResponseDocument.php
@@ -21,6 +21,7 @@
 namespace Picturae\OaiPmh;
 
 use GuzzleHttp\Psr7\Response;
+use Picturae\OaiPmh\Exception\NoRecordsMatchException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -102,7 +103,11 @@ class ResponseDocument
     public function addError(Exception $error)
     {
         $errorNode = $this->addElement("error", $error->getMessage());
-        $this->status = '400';
+
+        if (!$error instanceof NoRecordsMatchException) {
+            $this->status = '400';
+        }
+
         if ($error->getErrorName()) {
             $errorNode->setAttribute("code", $error->getErrorName());
         } else {


### PR DESCRIPTION
The OAI standard states:
-OAI-PMH errors are distinguished from HTTP Status-Codes
-OAI-PMH repositories **may** employ HTTP Status-Codes in addition to "200 OK"

This PR makes sure the NoRecordsMatchException error is served with a Status 200 response, as the current 400 status does not reflect the nature of the OAI response.